### PR TITLE
Updating the OAuth 2.0 Scope Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ nbdist/
 .nb-gradle/
 
 .mvn
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 docker-build:
 	docker-compose up -d
-	printf 'Wait for fdns-ms-combiner\n'
-	until `curl --output /dev/null --silent --head --fail http://localhost:8085`; do printf '.'; sleep 1; done
 	docker build \
 	  -t fdns-ms-reporting \
 		--network=fdns-ms-reporting_default \

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This microservice is designed to be used with other microservices. Please look a
 
 This microservice is configurable so that it can be secured via an OAuth 2 provider.
 
-__Scopes__: This application uses the following scope: `reporting.*`
+__Scopes__: This application uses the following scope: `fdns.reporting`
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: '3.1'
 services:
   zookeeper:
+    ports:
+      - "32181:32181"
     image: confluentinc/cp-zookeeper:3.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 32181
@@ -16,62 +18,7 @@ services:
     image: fluent/fluentd
     ports:
       - "24224:24224"
-  fdns-ms-storage:
-    image: cdcgov/fdns-ms-storage
-    depends_on:
-      - minio
+  fdns-ms-stubbing:
+    image: cdcgov/fdns-ms-stubbing
     ports:
-      - "8082:8082"
-  minio:
-    image: minio/minio
-    ports:
-      - "9000:9000"
-    environment:
-      MINIO_ACCESS_KEY: minio
-      MINIO_SECRET_KEY: minio123
-    command: server ~/Downloads/minio
-  fdns-ms-object:
-    image: cdcgov/fdns-ms-object
-    depends_on:
-      - mongo
-    ports:
-      - "8083:8083"
-  mongo:
-    image: mongo
-    ports:
-      - "27017:27017"
-  fdns-ms-indexing:
-    image: cdcgov/fdns-ms-indexing
-    depends_on:
-      - elastic
-    ports:
-      - "8084:8084"
-  elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.3.0
-    ports:
-      - "9200:9200"
-    environment:
-      - http.host=0.0.0.0
-      - transport.host=127.0.0.1
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - xpack.security.enabled=false
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
-  fdns-ms-combiner:
-    image: cdcgov/fdns-ms-combiner
-    depends_on:
-      - fdns-ms-object
-    ports:
-      - "8085:8085"
-  fdns-ms-msft-utils:
-    image: cdcgov/fdns-ms-msft-utils
-    ports:
-      - "8086:8086"
-    environment:
-      - "JAVA_OPTS=-Xms4096m -Xmx4096m -XX:PermSize=64M -XX:MaxPermSize=1000M"
+      - "3002:3002" 

--- a/src/main/java/gov/cdc/foundation/controller/ReportingController.java
+++ b/src/main/java/gov/cdc/foundation/controller/ReportingController.java
@@ -59,7 +59,10 @@ public class ReportingController {
 	private String kafkaTopicArchive;
 	private String kafkaTopicCombine;
 
-	private ReportingController(@Value("${kafka.topic.archive}") String kafkaTopicArchive, @Value("${kafka.topic.combine}") String kafkaTopicCombine) {
+	private ReportingController(
+		@Value("${kafka.topic.archive}") String kafkaTopicArchive,
+		@Value("${kafka.topic.combine}") String kafkaTopicCombine
+	) {
 		this.kafkaTopicArchive = kafkaTopicArchive;
 		this.kafkaTopicCombine = kafkaTopicCombine;
 	}
@@ -83,15 +86,19 @@ public class ReportingController {
 		}
 	}
 
-	@RequestMapping(value = "/jobs", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+	@RequestMapping(
+		value = "/jobs",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ResponseBody
 	public ResponseEntity<?> request(
-			Principal principal,
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestBody String reportRequest) throws IOException {
-
+		Principal principal,
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestBody String reportRequest
+	) throws IOException {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_REQUESTREPORT, reportRequest);
-
 		ObjectMapper mapper = new ObjectMapper();
 
 		try {
@@ -217,7 +224,10 @@ public class ReportingController {
 		}
 	}
 
-	private void checkAuthorization(JSONObject request, String username) throws Exception {
+	private void checkAuthorization(
+		JSONObject request,
+		String username
+	) throws Exception {
 		if (auth.isSecured()) {
 			// Get scopes
 			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -273,10 +283,16 @@ public class ReportingController {
 		}
 	}
 
-	@RequestMapping(value = "/jobs/{id}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+	@RequestMapping(
+		value = "/jobs/{id}",
+		method = RequestMethod.PUT,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ResponseBody
-	public ResponseEntity<?> restart(@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader, @ApiParam(value = "Job Id") @PathVariable(value = "id") String id) throws IOException {
-
+	public ResponseEntity<?> restart(
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@ApiParam(value = "Job Id") @PathVariable(value = "id") String id
+	) throws IOException {
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_RESTART);
 		log.put("jobId", id);
@@ -322,17 +338,27 @@ public class ReportingController {
 		}
 	}
 
-	@RequestMapping(value = "/jobs/{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@RequestMapping(
+		value = "/jobs/{id}",
+		method = RequestMethod.GET,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ResponseBody
-	public ResponseEntity<?> getProgress(@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader, @ApiParam(value = "Job Id") @PathVariable(value = "id") String id) throws IOException {
-
+	public ResponseEntity<?> getProgress(
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@ApiParam(value = "Job Id") @PathVariable(value = "id") String id
+	) throws IOException {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_REQUESTREPORT, id);
-
 		ObjectMapper mapper = new ObjectMapper();
 
 		try {
 			// Return the JSON object
-			return new ResponseEntity<>(mapper.readTree(ObjectHelper.getInstance(authorizationHeader).getObject(id).toString()), HttpStatus.OK);
+			return new ResponseEntity<>(
+				mapper.readTree(
+					ObjectHelper.getInstance(authorizationHeader).getObject(id).toString()
+				),
+				HttpStatus.OK
+			);
 		} catch (Exception e) {
 			logger.error(e);
 			LoggerHelper.log(MessageHelper.METHOD_REQUESTREPORT, log);

--- a/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
+++ b/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
@@ -34,7 +34,7 @@ public class OAuth2Configuration extends ResourceServerConfigurerAdapter {
 			http
 				.authorizeRequests()
 				.antMatchers(HttpMethod.OPTIONS).permitAll()
-				.antMatchers(protectedURIs).access("#oauth2.hasScope('reporting')")
+				.antMatchers(protectedURIs).access("#oauth2.hasScope('fdns.reporting')")
 				.anyRequest().permitAll();
 		else
 			http

--- a/src/test/java/gov/cdc/foundation/OAuth2Test.java
+++ b/src/test/java/gov/cdc/foundation/OAuth2Test.java
@@ -11,17 +11,23 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+import gov.cdc.helper.RequestHelper;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = { 
 		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224", 
 		"kafka.brokers=kafka:29092", 
-		"proxy.hostname=localhost",
-		"security.oauth2.resource.user-info-uri=",
-		"security.oauth2.protected=/**",
-		"security.oauth2.client.client-id=",
-		"security.oauth2.client.client-secret=",
+		"proxy.hostname=",
+		"security.oauth2.resource.user-info-uri=http://fdns-ms-stubbing:3002/oauth2/token/introspect",
+		"security.oauth2.protected=/api/1.0/**",
+		"security.oauth2.client.client-id=test",
+		"security.oauth2.client.client-secret=testsecret",
 		"ssl.verifying.disable=false" 
 	})
 @AutoConfigureMockMvc
@@ -30,11 +36,35 @@ public class OAuth2Test {
 	@Autowired
 	private TestRestTemplate restTemplate;
 	private String baseUrlPath = "/api/1.0/";
+	private String testToken = "Bearer testtoken";
 
 	@Test
-	public void indexPage() {
+	public void testUnauthenticated() {
 		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath, String.class);
 		assertThat(response.getStatusCodeValue()).isEqualTo(401);
 	}
 
+	@Test
+	public void testAthenticated() {
+		setScope("fdns.reporting");
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", testToken);
+		HttpEntity<String> request = new HttpEntity<String>("", headers);
+
+		ResponseEntity<String> response = this.restTemplate.exchange(
+			baseUrlPath,
+			HttpMethod.GET,
+			request,
+			String.class
+		);
+
+		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+	}
+
+	private void setScope(String scope) {
+		MultiValueMap<String, String> data = new LinkedMultiValueMap<>();
+		data.add("scope", scope);
+		RequestHelper.getInstance().executePost("http://fdns-ms-stubbing:3002/oauth2/mock", data);
+	}
 }

--- a/src/test/java/gov/cdc/foundation/ReportingApplicationErrorTests.java
+++ b/src/test/java/gov/cdc/foundation/ReportingApplicationErrorTests.java
@@ -21,7 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 				"logging.fluentd.host=fluentd",
 				"logging.fluentd.port=24224",
 				"kafka.brokers=kafka:29092",
-				"proxy.hostname=localhost",
+				"proxy.hostname=",
 				"security.oauth2.resource.user-info-uri=",
 				"security.oauth2.protected=",
 				"security.oauth2.client.client-id=",
@@ -35,13 +35,12 @@ public class ReportingApplicationErrorTests {
 	private MockMvc mvc;
 	private String baseUrlPath = "/api/1.0/";
 	
-
 	@Before
 	public void setup() {
 		// Define the object URL
-		System.setProperty("OBJECT_URL", "http://fdns-ms-object:8083");
+		System.setProperty("OBJECT_URL", "http://fdns-ms-stubbing:3002/object");
 		// Define the combiner URL
-		System.setProperty("COMBINER_URL", "http://fdns-ms-combiner:8085");
+		System.setProperty("COMBINER_URL", "http://fdns-ms-stubbing:3002/combiner");
 	}
 	
 	@Test

--- a/src/test/java/gov/cdc/foundation/ReportingApplicationTests.java
+++ b/src/test/java/gov/cdc/foundation/ReportingApplicationTests.java
@@ -30,10 +30,10 @@ import gov.cdc.helper.common.ServiceException;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = { 
-		"logging.fluentd.host=fluentd", 
-		"logging.fluentd.port=24224", 
-		"kafka.brokers=kafka:29092", 
-		"proxy.hostname=localhost",
+		"logging.fluentd.host=fluentd",
+		"logging.fluentd.port=24224",
+		"kafka.brokers=kafka:29092",
+		"proxy.hostname=",
 		"security.oauth2.resource.user-info-uri=",
 		"security.oauth2.protected=",
 		"security.oauth2.client.client-id=",
@@ -56,9 +56,9 @@ public class ReportingApplicationTests {
 		JacksonTester.initFields(this, objectMapper);
 		
 		// Define the object URL
-		System.setProperty("OBJECT_URL", "http://fdns-ms-object:8083");
+		System.setProperty("OBJECT_URL", "http://fdns-ms-stubbing:3002/object");
 		// Define the combiner URL
-		System.setProperty("COMBINER_URL", "http://fdns-ms-combiner:8085");
+		System.setProperty("COMBINER_URL", "http://fdns-ms-stubbing:3002/combiner");
 
 		// Add a config in combiner
 		int retries = 10;
@@ -115,7 +115,11 @@ public class ReportingApplicationTests {
 
 	public String createJob(String jsonQuery) throws Exception {
 		JSONObject query = new JSONObject(jsonQuery);
-		MvcResult result = mvc.perform(post(baseUrlPath + "/jobs").content(jsonQuery).contentType("application/json")).andExpect(status().isOk()).andReturn();
+		MvcResult result = mvc.perform(post(baseUrlPath + "/jobs")
+				.content(jsonQuery)
+				.contentType("application/json"))
+				.andExpect(status().isOk())
+				.andReturn();
 		JSONObject body = new JSONObject(result.getResponse().getContentAsString());
 		assertThat(body.getString("query").equals(query.getString("query")));
 		assertThat(body.getString("format").equals(query.getString("format")));


### PR DESCRIPTION
This pull request proposes a few changes:

- Changing the scopes to fall under a `fdns.*` namespace
- Adds support for CRUD operations (create, read, update and delete) and appends it at the end of the scope
- Adds support for wildcard scopes
- Adds the new https://github.com/CDCgov/fdns-ms-stubbing service for unit testing and tests OAuth 2.0 functionality